### PR TITLE
Added another auth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This Gradle plugin adds tasks to upload and download translation files from crow
 
 `crowdinDownload` downloads the latest translations and `crowdinUpload` uploads a source file. 
 
+Uses API v1.
+
 
 ## Usage
 
@@ -96,6 +98,25 @@ Point this at your source file, such as `values/strings.xml` and the task will u
 Note that the file must exist on crowdin, this simply acts as an updater. New files are not created.
 The files attribute expects a list of files where the name entry referrs to the file name used on crowdin and the source entry to the corresponding file in your project.
 This also allows you to batch upload strings.xml files from separate modules.
+
+## Identification
+
+Either use the combination of project identifier(**projectId**) and project key(**apiKey**) or combination of project identifier(**projectId**), username(**username**), and account key(**accountKey**) to authorize yourself.
+If they are all present in the configuration file, the second option is prioritized.
+
+    crowdinDownload {
+        
+        projectId = PROJECT_ID
+        
+        //First option
+        apiKey = CROWDIN_API_KEY
+        
+        //Second option, prioritized
+        username = USERNAME
+        accountKey = ACCOUNT_KEY
+        
+        //...
+    }
 
 ## Branches
 

--- a/plugin/src/main/groovy/com/mendhak/gradlecrowdin/DownloadTranslationsTask.groovy
+++ b/plugin/src/main/groovy/com/mendhak/gradlecrowdin/DownloadTranslationsTask.groovy
@@ -6,6 +6,8 @@ import org.gradle.api.tasks.TaskAction
 
 class DownloadTranslationsTask extends DefaultTask {
     def destination
+    def username
+    def accountKey
     def apiKey
     def projectId
     def renameMapping
@@ -20,7 +22,12 @@ class DownloadTranslationsTask extends DefaultTask {
         buildSubDir.mkdirs()
 
         //Tell Crowdin to do an export
-        def exportUrl = sprintf('https://api.crowdin.com/api/project/%s/export?key=%s', [projectId, apiKey])
+        def exportUrl = sprintf('https://api.crowdin.com/api/project/%s/export?', [projectId])
+        if (username != null && accountKey != null) {
+            exportUrl += sprintf('login=%s&account-key=%s', [username, accountKey])
+        } else {
+            exportUrl += sprintf('key=%s', apiKey)
+        }
         if (branch != null) {
             exportUrl += '&branch=' + branchEncoded
         }
@@ -28,7 +35,12 @@ class DownloadTranslationsTask extends DefaultTask {
         ant.get(src: exportUrl, dest: new File(buildSubDir.getPath(), "export.xml"), verbose: true)
 
         //Download actual zip file
-        def url = sprintf('https://api.crowdin.com/api/project/%s/download/%s.zip?key=%s', [projectId, 'all', apiKey])
+        def url = sprintf('https://api.crowdin.com/api/project/%s/download/%s.zip?', [projectId, 'all'])
+        if (username != null && accountKey != null) {
+            url += sprintf('login=%s&account-key=%s', [username, accountKey])
+        } else {
+            url += sprintf('key=%s', apiKey)
+        }
         if (branch != null) {
             url += '&branch=' + branchEncoded
         }

--- a/plugin/src/main/groovy/com/mendhak/gradlecrowdin/UploadSourceFileTask.groovy
+++ b/plugin/src/main/groovy/com/mendhak/gradlecrowdin/UploadSourceFileTask.groovy
@@ -11,6 +11,8 @@ import org.apache.http.entity.mime.content.FileBody
 
 
 class UploadSourceFileTask extends DefaultTask {
+    def username
+    def accountKey
     def apiKey
     def projectId
     def files
@@ -27,7 +29,12 @@ class UploadSourceFileTask extends DefaultTask {
             uploadType = 'update'
         }
 
-        def updateFilePath = sprintf('https://api.crowdin.com/api/project/%s/%s-file?key=%s', [projectId, uploadType, apiKey])
+        def updateFilePath = sprintf('https://api.crowdin.com/api/project/%s/%s-file?', [projectId, uploadType])
+        if (username != null && accountKey != null) {
+             updateFilePath += sprintf('login=%s&account-key=%s', [username, accountKey])
+        } else {
+            updateFilePath += 'key=' + apiKey
+        }
         if (branch != null) {
             updateFilePath += '&branch=' + branchEncoded
         }
@@ -62,7 +69,14 @@ class UploadSourceFileTask extends DefaultTask {
      * */
     private boolean createBranch(String branchEncoded) {
         def created = false
-        def addBranchPath = sprintf('https://api.crowdin.com/api/project/%s/add-directory?key=%s&name=%s&is_branch=1', [projectId, apiKey, branchEncoded])
+        def addBranchPath = sprintf('https://api.crowdin.com/api/project/%s/add-directory?', [projectId])
+        if (username != null && accountKey != null) {
+            addBranchPath += sprintf('login=%s&account-key=%s', [username, accountKey])
+        } else {
+            addBranchPath += sprintf('key=%s', apiKey)
+        }
+        addBranchPath += sprintf("&name=%s&is_branch=1", [branchEncoded])
+
         new HTTPBuilder(addBranchPath).request(Method.POST, ContentType.ANY) { req ->
             response.failure = { resp, reader ->
                 if (reader.code.text() != '50') {


### PR DESCRIPTION
Hello,

Not so long ago, Crowdin [released API v2](https://blog.crowdin.com/2020/08/05/announcing-the-new-API-2.0/?utm_source=release-notes&utm_medium=crowdin-ui) and began to gradually abandon API v1 (but it will stay fully functional until the end of 2021).

API v1 has two options to make requests - by API project key and by API account key.

For example:

    POST https://api.crowdin.com/api/project/{project-identifier}/add-file?key={project-key}

    POST https://api.crowdin.com/api/project/{project-identifier}/add-file?login={username}&account-key={account-key}

Recently API project key was hidden in project settings, and for new users, it remains only to use API account key.

In this PR I added the ability to use the second option.